### PR TITLE
Update links to this repo and add clear download link in readme

### DIFF
--- a/Anno1800ModLauncher/Views/AboutView.xaml
+++ b/Anno1800ModLauncher/Views/AboutView.xaml
@@ -52,7 +52,7 @@
                 <LineBreak />- <Run Text="{DynamicResource AboutMessageRebuilt}"/> <Hyperlink NavigateUri="https://www.notion.so/Anno-1800-Mod-Manager-Wiki-60bbcd8ad9634c2faa225be3f1bd46d6" RequestNavigate="Hyperlink_RequestNavigate">
                     <TextBlock Text="{DynamicResource AboutMessageWikiText}"/>
                 </Hyperlink>
-                <LineBreak />- <Run Text="{DynamicResource AboutMessageContributors}"/> <Hyperlink NavigateUri="https://github.com/LemonDrop1228/anno1800-mod-manager" RequestNavigate="Hyperlink_RequestNavigate">
+                <LineBreak />- <Run Text="{DynamicResource AboutMessageContributors}"/> <Hyperlink NavigateUri="https://github.com/RebuiltStatue21/AMM-Source-Code" RequestNavigate="Hyperlink_RequestNavigate">
                     <TextBlock Text="{DynamicResource AboutMessageGithub}"/>
                 </Hyperlink>
             </TextBlock>

--- a/README.md
+++ b/README.md
@@ -4,21 +4,41 @@ Just for some users concerned [Here](https://www.virustotal.com/gui/file/6aa923b
 
 Download latest Mod Manager from [Release section](https://github.com/RebuiltStatue21/AMM-Source-Code/releases).
 
-# Mod Description
-AMM is a mod manager, game launcher, and news hub for Anno 1800. It uses the processes in place and made popular by xforce for modding. It does NOT replace xforce's Mod Loader, but simply installs it from his github repository, and manages the mods in your mod directory through an easy to use UI.
-# What This Mod Does
+## Mod Description
+
+AMM is a mod manager, game launcher, and news hub for Anno 1800.
+It uses the processes in place and made popular by xforce for modding.
+It does NOT replace xforce's Mod Loader, but simply installs it from his github repository, and manages the mods in your mod directory through an easy to use UI.
+
+## What This Mod Does
+
 - Launches the game for you directly from the app.
 - Provides for easy access to the latest Anno 1800 news.
 - Manages mod directory creation.
 - Manages installation of the mod loader files.
 - Allows you to activate/deactivate mods with ease.
 - Keeps itself and the mod loader files up-to-date so that you don't have to.
-# For Mod Creators
-If you would like to work out other features or integrations, or have ideas feel free to reach out to me! The application automatically pulls in the content, and readme text files from the mods root directory. It also looks for a banner.png image file to load as the banner for the mod. If no banner is found it uses a placeholder. Simply including these files in your zip file will allow theme to be shown to users automatically.\
-# About Anno 1800 Mod Manager and The Dev
-The mod launcher is a passion project that I felt the Anno Community deserves. I myself prefer mod launchers that are focused on one specific game as they are usually able to address concerns regarding the game more quickly and efficiently. I noticed that the mod community around this game has created some pretty awesome mods, and xforce was extremely kind enough to create an awesome mod loader that works extremely well. the only piece of the puzzle left was a Mod loader that brought that all together in an easy to use tool.
-I'm a gamer myself and have been playing Anno Games for years. On top of that, I'm a married father with a full-time job, so my time is precious to me and those around me. I created this out of love and passion for programming so I appreciate that you took the time to check it out. Please feel free to make suggestions, comments, or even take occasional grope over on the official discord server for the app: [Anno 1800 Mod Manager Official Discord Server](https://discord.com/invite/eZsxQXS)
+
+## For Mod Creators
+
+If you would like to work out other features or integrations, or have ideas feel free to reach out to me!
+The application automatically pulls in the content, and readme text files from the mods root directory.
+It also looks for a banner.png image file to load as the banner for the mod.
+If no banner is found it uses a placeholder.
+Simply including these files in your zip file will allow theme to be shown to users automatically.
+
+## About Anno 1800 Mod Manager and The Dev
+
+The mod launcher is a passion project that I felt the Anno Community deserves.
+I myself prefer mod launchers that are focused on one specific game as they are usually able to address concerns regarding the game more quickly and efficiently.
+I noticed that the mod community around this game has created some pretty awesome mods, and xforce was extremely kind enough to create an awesome mod loader that works extremely well.
+the only piece of the puzzle left was a Mod loader that brought that all together in an easy to use tool.
+I'm a gamer myself and have been playing Anno Games for years.
+On top of that, I'm a married father with a full-time job, so my time is precious to me and those around me.
+I created this out of love and passion for programming so I appreciate that you took the time to check it out.
+Please feel free to make suggestions, comments, or even take occasional grope over on the official discord server for the app: [Anno 1800 Mod Manager Official Discord Server](https://discord.com/invite/eZsxQXS)
 Special thanks to Xforce for creating the [Anno 1800 Mod Loader](https://github.com/xforce/anno1800-mod-loader)
 
-# Wiki
+## Wiki
+
 If you have any issues with the AMM or want a visual of the roadmap needs please take a look at the [Wiki](https://www.notion.so/Anno-1800-Mod-Manager-Wiki-60bbcd8ad9634c2faa225be3f1bd46d6)!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Anno 1800 Mod Manager
 A c# WPF app that helps you to manage your modded Anno 1800 experience.
 Just for some users concerned [Here](https://www.virustotal.com/gui/file/6aa923b86f1298bcd6df08d3d9647ebb15ed4880b78b2ee4f7ab602ba42e6c3d/detection) is the virustotal scan
+
+Download latest Mod Manager from [Release section](https://github.com/RebuiltStatue21/AMM-Source-Code/releases).
+
 # Mod Description
 AMM is a mod manager, game launcher, and news hub for Anno 1800. It uses the processes in place and made popular by xforce for modding. It does NOT replace xforce's Mod Loader, but simply installs it from his github repository, and manages the mods in your mod directory through an easy to use UI.
 # What This Mod Does


### PR DESCRIPTION
Hey, the links flying all over the internet regarding the AMM are quite confusing. Most of them point to older versions.

I also recommend adding a clear download link to the readme and update all links to just point to this repository. People who just want to download binaries should also see the readme first.

I reformatted the readme a bit on the way, you can just drop the second commit if you don't like it.